### PR TITLE
Rules for dropdown component in experience doc

### DIFF
--- a/design-language/experience.md
+++ b/design-language/experience.md
@@ -32,7 +32,7 @@ To assist user and provide context and clarity about a field’s input you can u
 As with all form content, help text should be succinct and easy to read. 
 
 For brief explanations (shorter than a sentence), place the text underneath the field.
-If the explanation is lengthy, use a {{component}}. 
+If the explanation is lengthy, use in-line expansion. 
 
 Help text should not be correlated with placeholder, label or tip patterns/compoenents and should be used differently and per use case.
 

--- a/design-language/experience.md
+++ b/design-language/experience.md
@@ -1,22 +1,24 @@
 # Experience
 
-As UX team we think, plan and design according to the following axioms:
-✓ You are thoughtful with everything you do and strive to provide the best and most
-elegant solutions, even if it means sacrificing things that are urgent.
-✓ You choose simple over complex. You prefer to be explicit than implicit, even if it
-feels obvious.
-✓ You communicate and build our products in clear, simple ways instead of being
-clever.
-✓ Among competing hypotheses, you choose the one with the fewest assumptions
-( Occam’s razor ↗ ).
-✓ You prefer to do something well today rather than something perfect next week.
+As UX team we choose simple over complex and prefer to be explicit than implicit, even if it
+feels obvious. We try to communicate and build our products in clear, simple ways instead of being clever. Following are some specs and rules about certain components and interactions.
 
-We focus on users’ goals that lead people to actionable insights. We are proactive, always anticipating users’ next moves and helping them prepare for change.
-Our products and services are framed by six universal experiences. Each experience offers opportunities to solve unmet needs and emotionally bond users to products. 
 
-The core principles of user experience in Transifex products are:
-Focus ✏️
-Clarity ✏️
-Consistency ✏️
-Efficiency ✏️
-Simplicity ✏️
+
+
+## Dropdown menus
+Dropdown menus display options for list items, and they immediately commit choices upon selection. Dropdown options can be single and multi-level with the difference that for the latter a visual cue is needed such as an right arrow. For selected options a checked mark should be added.
+
+#### Click mechanics:
+- Choosing an option immediately commits the option and closes the menu
+- Clicking outside of the dialog, or pressing ESC, cancels the action and closes the dialog
+
+#### Content
+Dropdown menu content typically consists of text and/or UI control elements. It is focused on a specific task, such as choosing a setting or option.
+
+#### Actions
+Dropdowns should not include more than two actions. A third action, such as “Learn more,” navigates away from the dialog, potentially leaving the task unfinished.
+
+Avoid using a “Learn more” action to access help documentation; in-line expansion within the dialog should be used instead. If more extensive information is needed, provide it prior to entering the dropdown.
+
+

--- a/design-language/experience.md
+++ b/design-language/experience.md
@@ -22,3 +22,27 @@ Dropdowns should not include more than two actions. A third action, such as “L
 Avoid using a “Learn more” action to access help documentation; in-line expansion within the dialog should be used instead. If more extensive information is needed, provide it prior to entering the dropdown.
 
 
+---
+
+
+## Help text
+To assist user and provide context and clarity about a field’s input you can use help text. 
+
+#### Usage
+As with all form content, help text should be succinct and easy to read. 
+
+For brief explanations (shorter than a sentence), place the text underneath the field.
+If the explanation is lengthy, use a {{component}}. 
+
+Help text should not be correlated with placeholder, label or tip patterns/compoenents and should be used differently and per use case.
+
+You can also use placeholder text to provide an example of the type of input required. For example, in a Name field, show a name in the correct format.
+
+
+#### Do / Don’t
+- Help text should be placed below the text field
+- Don't use Learn more & navigate away from the dialog
+- Left justified 
+- On a single line if possible, or with text wrapping (if multiple lines)
+- Use in-line expansion within the dialog for lengthy help text
+

--- a/design-language/experience.md
+++ b/design-language/experience.md
@@ -3,9 +3,6 @@
 As UX team we choose simple over complex and prefer to be explicit than implicit, even if it
 feels obvious. We try to communicate and build our products in clear, simple ways instead of being clever. Following are some specs and rules about certain components and interactions.
 
-
-
-
 ## Dropdown menus
 Dropdown menus display options for list items, and they immediately commit choices upon selection. Dropdown options can be single and multi-level with the difference that for the latter a visual cue is needed such as an right arrow. For selected options a checked mark should be added.
 
@@ -21,9 +18,7 @@ Dropdowns should not include more than two actions. A third action, such as “L
 
 Avoid using a “Learn more” action to access help documentation; in-line expansion within the dialog should be used instead. If more extensive information is needed, provide it prior to entering the dropdown.
 
-
 ---
-
 
 ## Help text
 To assist user and provide context and clarity about a field’s input you can use help text. 
@@ -32,7 +27,7 @@ To assist user and provide context and clarity about a field’s input you can u
 As with all form content, help text should be succinct and easy to read. 
 
 For brief explanations (shorter than a sentence), place the text underneath the field.
-If the explanation is lengthy, use in-line expansion. 
+**If the explanation is lengthy, don't use a help text! Help text should be short!**
 
 Help text should not be correlated with placeholder, label or tip patterns/compoenents and should be used differently and per use case.
 
@@ -41,8 +36,8 @@ You can also use placeholder text to provide an example of the type of input req
 
 #### Do / Don’t
 - Help text should be placed below the text field
-- Don't use Learn more & navigate away from the dialog
-- Left justified 
+- Left aligned 
 - On a single line if possible, or with text wrapping (if multiple lines)
-- Use in-line expansion within the dialog for lengthy help text
+- Don't write more than 2-3 lines of text.
+- Keep it short! 
 


### PR DESCRIPTION
# Intro

Helptext principles and patterns when used in dropdown menus or UI in general.
Visuals: https://invis.io/TJHKU3AAY5X


## Refs

Salesfore
https://www.lightningdesignsystem.com/guidelines/data-entry/#site-main-content

> Input Help
> To assist the users, you can add help text. If the explanation is lengthy, use an “info” icon and tooltip. For brief explanations (shorter than a sentence), you can place the text underneath the field.
> You can also use placeholder text to provide an example of the type of input required. For example, in a Name field, show a name in the correct format.

Google
https://material.io/guidelines/components/dialogs.html#dialogs-specs
https://material.io/guidelines/components/text-fields.html#text-fields-layout

> Helper text
> Helper text gives context about a field’s input, such as how the input will be used.
> It should be visible either persistently or only on focus.
> Specs:
> Left justified
> On a single line if possible, or with text wrapping (if multiple lines)


Shopify
https://polaris.shopify.com/components/forms/text-field#section-content-guidelines

> Help text
> Help text provides extra guidance or instruction to people filling out a form field. It can also be used to clarify how the information will be used. As with all form content, help text should be succinct and easy to read.
> 